### PR TITLE
修复载具附身obj不能保存的问题

### DIFF
--- a/pawno/include/common/Cars.inc
+++ b/pawno/include/common/Cars.inc
@@ -1781,7 +1781,7 @@ stock SetupCarsTable() {
 
 // 2021.10.7 修复TagObject没有默认值的问题
     mysql_pquery(g_Sql,"CREATE TABLE IF NOT EXISTS `va`  (\
-    `ID` int(10) UNSIGNED NOT NULL DEFAULT 0,\
+    `ID` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,\
     `VehicleID` int(11) NULL DEFAULT NULL,\
     `Slot` int(11) NULL DEFAULT NULL,\
     `Model` int(11) NULL DEFAULT NULL,\


### PR DESCRIPTION
之前 va 表中的 ID 字段默认值为0,不是自增的,并且 va 表主键也是 ID,所以插入数据的时候会报1062 duplicate entry 0 for key primary的错误